### PR TITLE
switch to static library

### DIFF
--- a/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
+++ b/Source/ObjectiveDropboxOfficial/ObjectiveDropboxOfficial.xcodeproj/project.pbxproj
@@ -5125,6 +5125,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dropbox.ObjectiveDropboxOfficial;
 				PRODUCT_NAME = ObjectiveDropboxOfficial;
 				SKIP_INSTALL = YES;
@@ -5152,6 +5153,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dropbox.ObjectiveDropboxOfficial;
 				PRODUCT_NAME = ObjectiveDropboxOfficial;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
https://readdle-j.atlassian.net/browse/EXP-16060

Switch to static library so that the SDK is incapsulated only in our Dropbox Client framework and we don't have to embed it into the main app copy frameworks phase

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures the iOS ObjectiveDropboxOfficial target to build as a static library.
> 
> - **Build configuration (Xcode project)**:
>   - Set `MACH_O_TYPE = staticlib` for `ObjectiveDropboxOfficial` iOS target in `Debug` and `Release` to produce a static library.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f7540b854f1706d2e4fd3a27e662c3841e544d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->